### PR TITLE
Choose another repository for pkg-isocodes

### DIFF
--- a/modulesets/gnucash.modules
+++ b/modulesets/gnucash.modules
@@ -40,7 +40,7 @@
   <include href="gtkhtml.modules"/>
 
   <autotools id="iso-codes" autogen-sh="configure">
-    <branch module="iso-codes_3.23.orig.tar.bz2" version="3.23" repo="iso-codes" checkoutdir="iso-codes-3.23"/>
+    <branch module="iso-codes_3.28.orig.tar.bz2" version="3.28" repo="iso-codes" checkoutdir="iso-codes-3.28"/>
   </autotools>
 
  <autotools id="libchipcard" autogen-sh="configure" >


### PR DESCRIPTION
Hi John,

The current repo for pkg-isocodes (pkg-isocodes.alioth.debian.org) has been refusing connections for quite some time from my desk. So I propose change it to a different one that does work.

Regards,

Geert
