### PR TITLE
Info.plist: fix spelling of CFBundleTypeIconFile

### DIFF
--- a/gnucash-bundler/Info.plist
+++ b/gnucash-bundler/Info.plist
@@ -35,7 +35,7 @@
 	    <array>
 	      <string>gnucash</string>
 	    </array>
-	    <key>CFBundlieTypeIconFile</key>
+	    <key>CFBundleTypeIconFile</key>
 	    <string>gnucash.icns</string>
 	    <key>CFBundleTypeRole</key>
 	    <string>Editor</string>
@@ -49,7 +49,7 @@
 	      <string>ofx</string>
 	      <string>txf</string>
 	    </array>
-	    <key>CFBundlieTypeIconFile</key>
+	    <key>CFBundleTypeIconFile</key>
 	    <string>gnucash.icns</string>
 	    <key>CFBundleTypeRole</key>
 	    <string>Viewer</string>


### PR DESCRIPTION
This patch, coupled with [lsregister -kill](http://www.tuaw.com/2009/06/11/terminal-tips-rebuild-your-launch-services-database-to-clean-up/) to re-read the old Info.plist, yields Gnucash icons on *.ofx files.

Thanks for all your hard work on the app bundle - it's working well for me so far.
