### PR TITLE
Use the GNOME repo for xmlsec

### DIFF
--- a/modulesets/gnucash.modules
+++ b/modulesets/gnucash.modules
@@ -76,7 +76,7 @@
   </autotools>
 
   <autotools id="xmlsec">
-    <branch module="mogigoma/xmlsec" repo="github"/>
+    <branch module="GNOME/xmlsec" repo="github"/>
     <dependencies>
       <dep package="openssl"/>
     </dependencies>


### PR DESCRIPTION
The previous repository for xmlsec no longer exists
(mogigoma/xmlsec)