### PR TITLE
Fix readme header

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,4 +1,4 @@
-#Building GnuCash with GTK-OSX#
+# Building GnuCash with GTK-OSX #
 
 GnuCash can be built to run more or less natively on OSX -- meaning
 without X11. Better yet, the build is almost automatic.


### PR DESCRIPTION
GitHub changed their markdown rendering so that the hash requires a space.